### PR TITLE
Add more spectraVariables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(person(given = "Christian",
 	  email = "Tobias.Kockmann@fgcz.ethz.ch", role = "aut", 
       comment = c(ORCID = "0000-0002-1847-885X")),
     person(given = "Roger", family = "Gine Bertomeu",
-      email = "roger.gine@iispv.cat", role = "aut",
+      email = "roger.gine@iispv.cat", role = "ctb",
       comment = c(ORCID = "0000-0003-0288-9619")))
 Depends: R (>= 4.1), methods, Spectra (>= 1.5.8)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,16 @@
 Package: MsBackendRawFileReader
 Type: Package
 Title: Mass Spectrometry Backend for Reading Thermo Fisher Scientific raw Files
-Version: 1.1.16
+Version: 1.1.17
 Authors@R: c(person(given = "Christian",
     family = "Panse", email = "cp@fgcz.ethz.ch", role = c("aut", "cre"),
     comment = c(ORCID = "0000-0003-1975-3064")),
 	person(given = "Tobias", family = "Kockmann",
 	  email = "Tobias.Kockmann@fgcz.ethz.ch", role = "aut", 
-    comment = c(ORCID = "0000-0002-1847-885X")))
+      comment = c(ORCID = "0000-0002-1847-885X")),
+    person(given = "Roger", family = "Gine Bertomeu",
+      email = "roger.gine@iispv.cat", role = "aut",
+      comment = c(ORCID = "0000-0003-0288-9619")))
 Depends: R (>= 4.1), methods, Spectra (>= 1.5.8)
 Imports:
     MsCoreUtils,

--- a/tests/testthat/test_multiple.R
+++ b/tests/testthat/test_multiple.R
@@ -28,7 +28,7 @@ test_that("filterScan", {
 })
 
 test_that("collisionEnergy", {
-    expect_type(collisionEnergy(sample_raw), "list")
+    expect_type(collisionEnergy(sample_raw), "numeric")
     expect_equal(collisionEnergy(sample_raw)[[1]], numeric(0)) #MS1 scan
     expect_equal(collisionEnergy(sample_raw)[[2]], 28) #MS2 scan
 })

--- a/tests/testthat/test_multiple.R
+++ b/tests/testthat/test_multiple.R
@@ -27,6 +27,28 @@ test_that("filterScan", {
                      sapply(FUN=length)) == c(27, 546, 573)))
 })
 
+test_that("collisionEnergy", {
+    expect_type(collisionEnergy(sample_raw), "list")
+    expect_equal(collisionEnergy(sample_raw)[[1]], numeric(0)) #MS1 scan
+    expect_equal(collisionEnergy(sample_raw)[[2]], 28) #MS2 scan
+})
+
+test_that("isolationWindow funs", {
+    expect_type(isolationWindowLowerMz(sample_raw), "double")
+    expect_type(isolationWindowTargetMz(sample_raw), "double")
+    expect_type(isolationWindowUpperMz(sample_raw), "double")
+    
+    #MS1 scan, should be NA
+    expect_equal(isolationWindowLowerMz(sample_raw)[1], NA_real_)
+    expect_equal(isolationWindowTargetMz(sample_raw)[1], NA_real_)
+    expect_equal(isolationWindowUpperMz(sample_raw)[1], NA_real_)
+    
+    #MS2 scan
+    expect_equal(isolationWindowLowerMz(sample_raw)[2], 486.5567, tolerance = 1e-4)
+    expect_equal(isolationWindowTargetMz(sample_raw)[2], 487.2567, tolerance = 1e-4)
+    expect_equal(isolationWindowUpperMz(sample_raw)[2], 487.9567, tolerance = 1e-4)
+})
+
 test_that("peaksData", {
   P <- (sample_raw |>
           filterScan("ms2 517.7398@hcd28.00"))[1:2] |>


### PR DESCRIPTION
Hi there @cpanse @tobiasko! 
Here's my PR for parsing more `spectraVariables `from the `rawrrSpectrum` objects. Related to issue #17.

Basically, I've copied the existing strategy of reading a few spectra at a time: I created a reusable function (`.spectrum_get`) that applies a supplied FUN function during the `lapply` so that one may extract whatever they want from the rawrrSpectrum. In this case, `.get_spectrum_metadata` uses a (expandable) dictionary of known variables and extracts whatever it finds.

Then a post-processing function cleans up the columns (type conversion, whitespace removal, etc.) , calculates "derivative" variables (eg. MS2 isolation mz bounds (lower, target, upper) from the precursorMz + isolationOffset +- isolationWidth), etc.

I created some basic tests for the added variables that are present in `coreSpectraVariables`. 
AFAIK, everything is working as intended, both with the package test data and some IDX data of my own, but I'd like you to also give it a try and see if there's any other variables you want added 👍 

